### PR TITLE
render forms (group1, group2, group3)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,44 +1,37 @@
+import { Grid } from '@material-ui/core';
 import React from 'react';
 import './App.css';
-import {Autocomplete} from "@material-ui/lab";
-import {TextField} from "@material-ui/core";
-
-const arr1 = ['item 1', 'item 2', 'item 3'];
-const arr2 = ['item 1', 'item 2', 'item 3'];
-const arr3 = ['item 1', 'item 2', 'item 3'];
+import { Group1 } from "./components/Group1";
+import {Group2, Group2Value} from './components/Group2';
+import { Group3 } from './components/Group3';
 
 function App() {
-  const [input1, setInput1] = React.useState<string | null>(null);
-  const [input2, setInput2] = React.useState<string | null>(null);
-  const [input3] = React.useState<string | null>(null);
+  const [group1Value, setGroup1Value] = React.useState<number>(1);
+  const [group2Values, setGroup2Values] = React.useState<Group2Value[]>([]);
+
 
   return (
     <div className="App">
-      <Autocomplete
-        id="input1"
-        value={input1}
-        options={arr1}
-        renderInput={(params) => <TextField {...params} label="Input 1" variant="outlined"/>}
-        onChange={(e, v) => setInput1(v)}
-      />
-      {input1 && <Autocomplete
-        id="input2"
-        value={input2}
-        options={arr2}
-        renderInput={(params) => <TextField {...params} label="Input 2" variant="outlined"/>}
-        onChange={(e, v) => setInput2(v)}
-      />}
-      {input2 && <Autocomplete
-        id="input3"
-        value={input3}
-        options={arr3}
-        renderInput={(params) => <TextField {...params} label="Input 3" variant="outlined"/>}
-        onChange={(e, v) => {
-          setInput1(null);
-          setInput2(null);
-        }
-        }
-      />}
+      <Grid container direction="column" alignContent="flex-start">
+        <Group1 value={group1Value} setValue={setGroup1Value} />
+        {[...Array(group1Value)].map((v, index) => {
+          return <Group2
+            key={`group2_${index}`}
+            index={index}
+            onSetValues={(values) => {
+              const newValues = [...group2Values];
+              newValues[index] = values;
+
+              setGroup2Values(newValues);
+            }}
+          />;
+        })}
+        <Group3 onButtonPress={() => {
+          const trimmedValues = [...group2Values];
+          trimmedValues.splice(group1Value);
+          console.log(trimmedValues);
+        }} />
+      </Grid>
     </div>
   );
 }

--- a/src/components/Group1.tsx
+++ b/src/components/Group1.tsx
@@ -1,0 +1,25 @@
+import React from "react";
+import {RadioGroup, FormControlLabel, Radio, FormControl, FormLabel, Grid} from "@material-ui/core";
+
+const Group1: React.FC<{ value: number, setValue: (value: number) => void }> = ({value, setValue}) => {
+  const handleChange = (event: any) => {
+    setValue(parseInt(event.target.value));
+  };
+
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">Group 1</FormLabel>
+      <RadioGroup aria-label="group1" name="group1" value={value.toString()} onChange={handleChange}>
+        <Grid container direction="row">
+          {[...Array(10)].map((v, index) => {
+            const option = index + 1;
+            return <FormControlLabel key={`group1_radio_${option}`} value={option.toString()} control={<Radio/>}
+                                     label={option.toString()}/>;
+          })}
+        </Grid>
+      </RadioGroup>
+    </FormControl>
+  );
+}
+
+export {Group1}

--- a/src/components/Group2.tsx
+++ b/src/components/Group2.tsx
@@ -25,7 +25,7 @@ const Group2: React.FC<{index: number, onSetValues: (values: Group2Value) => voi
     <FormControl component="fieldset">
       <FormLabel component="legend">Group 2 - Index: {index}</FormLabel>
       <Autocomplete
-        id="input1"
+        id={`group2_input1_${index}`}
         value={input1}
         options={arr1}
         renderInput={(params) => <TextField {...params} label="Input 1" variant="outlined"/>}
@@ -35,7 +35,7 @@ const Group2: React.FC<{index: number, onSetValues: (values: Group2Value) => voi
         }}
       />
       {input1 && <Autocomplete
-        id="input2"
+        id={`group2_input2_${index}`}
         value={input2}
         options={arr2}
         renderInput={(params) => <TextField {...params} label="Input 2" variant="outlined"/>}
@@ -45,7 +45,7 @@ const Group2: React.FC<{index: number, onSetValues: (values: Group2Value) => voi
         }}
       />}
       {input2 && <Autocomplete
-        id="input3"
+        id={`group2_input3_${index}`}
         value={input3}
         options={arr3}
         renderInput={(params) => <TextField {...params} label="Input 3" variant="outlined"/>}

--- a/src/components/Group2.tsx
+++ b/src/components/Group2.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import {FormControl, FormLabel, TextField} from "@material-ui/core";
+import {Autocomplete} from "@material-ui/lab";
+
+const arr1 = ['item 1', 'item 2', 'item 3'];
+const arr2 = ['item 1', 'item 2', 'item 3'];
+const arr3 = ['item 1', 'item 2', 'item 3'];
+
+interface Group2Value {
+  input1: string | null;
+  input2: string | null;
+  input3: string | null;
+}
+
+const Group2: React.FC<{index: number, onSetValues: (values: Group2Value) => void}> = ({index, onSetValues}) => {
+  const [input1, setInput1] = React.useState<string | null>(null);
+  const [input2, setInput2] = React.useState<string | null>(null);
+  const [input3, setInput3] = React.useState<string | null>(null);
+
+  React.useEffect(() => {
+    onSetValues({input1, input2, input3});
+  }, [input1, input2, input3]);
+
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">Group 2 - Index: {index}</FormLabel>
+      <Autocomplete
+        id="input1"
+        value={input1}
+        options={arr1}
+        renderInput={(params) => <TextField {...params} label="Input 1" variant="outlined"/>}
+        onChange={(e, v) => {
+          setInput1(v);
+          onSetValues({input1: v, input2, input3})
+        }}
+      />
+      {input1 && <Autocomplete
+        id="input2"
+        value={input2}
+        options={arr2}
+        renderInput={(params) => <TextField {...params} label="Input 2" variant="outlined"/>}
+        onChange={(e, v) => {
+          setInput2(v);
+          onSetValues({input1, input2: v, input3})
+        }}
+      />}
+      {input2 && <Autocomplete
+        id="input3"
+        value={input3}
+        options={arr3}
+        renderInput={(params) => <TextField {...params} label="Input 3" variant="outlined"/>}
+        onChange={(e, v) => {
+          setInput3(v);
+          onSetValues({input1, input2, input3: v})
+        }}
+      />}
+    </FormControl>
+  );
+}
+
+export { Group2 }
+export type { Group2Value }

--- a/src/components/Group3.tsx
+++ b/src/components/Group3.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import {Button, FormControl, FormLabel} from "@material-ui/core";
+
+const Group3: React.FC<{onButtonPress: () => void}> = ({onButtonPress}) => {
+  return (
+    <FormControl component="fieldset">
+      <FormLabel component="legend">Group 3</FormLabel>
+      <Button variant="contained" onClick={onButtonPress}>LOG</Button>
+      <Button variant="contained" color="primary" onClick={onButtonPress}>
+        LOG
+      </Button>
+    </FormControl>
+  );
+}
+
+export { Group3 }


### PR DESCRIPTION
UI
Group1 - Radio buttons with 10 options, values ranging from 1 - 10.
Group2 - 3 select inputs (material-ui autocomplete component)
Group3 - 2 Buttons

Logic
Group1 - Only 1 option can be selected
Group2 - Whatever the value of `Group1` is, `Group2` should be rendered that many times. E.g. if `Group1` value is 2 then Group2 should render twice.
Group3 - On click on either button should log the state of Group2. E.g. if Group2 was rendered twice, the state would look something like [{input1:value,input2:value,input3:value},{input1:value,input2:value,input3:value}].

App
My existing React app just has `Group2 ` UI and needs to be modified to implement the remaining.

Technical Requirements:
Material UI Solution Only
No CSS/No style tag - Use component props for styling
Do not add any library to package.json